### PR TITLE
Include underscore in bundle id validation

### DIFF
--- a/app_distribution_server/build_info.py
+++ b/app_distribution_server/build_info.py
@@ -50,9 +50,9 @@ class LegacyAppInfo(BaseModel):
 
     @field_validator("bundle_id")
     def validate_bundle_id(cls, v):
-        if not re.match(r"^[a-zA-Z0-9\.\-]{1,256}$", v):
+        if not re.match(r"^[a-zA-Z0-9\.\-\_]{1,256}$", v):
             raise ValueError(
-                "Bundle ID can only contain alphanumeric characters, dots and hyphens."
+                "Bundle ID can only contain alphanumeric characters, dots, hyphens and underscores."
             )
         return v
 

--- a/app_distribution_server/routers/api_router.py
+++ b/app_distribution_server/routers/api_router.py
@@ -137,7 +137,7 @@ router.delete(
 )
 def api_get_latest_upload_by_bundle_id(
     bundle_id: str = Path(
-        pattern=r"^[a-zA-Z0-9\.\-]{1,256}$",
+        pattern=r"^[a-zA-Z0-9\.\-\_]{1,256}$",
     ),
 ) -> BuildInfo:
     upload_id = get_latest_upload_id_by_bundle_id(bundle_id)


### PR DESCRIPTION
For Android underscore (_) is a valid character for use in bundle id.