### PR TITLE
fix: encode Unicode filenames in Content-Disposition headers

### DIFF
--- a/app_distribution_server/routers/app_files_router.py
+++ b/app_distribution_server/routers/app_files_router.py
@@ -68,9 +68,9 @@ async def get_app_file(
         build_info.created_at.strftime("%Y-%m-%d_%H-%M-%S") if build_info.created_at else ""
     )
     file_name = f"{build_info.app_title} {build_info.bundle_version}{created_at_prefix}"
-    
+
     # Encode the filename for HTTP headers
-    safe_filename = quote(file_name) 
+    safe_filename = quote(file_name)
     content_disposition = f"attachment; filename*=UTF-8''{safe_filename}.{file_type}"
 
     return Response(

--- a/app_distribution_server/routers/app_files_router.py
+++ b/app_distribution_server/routers/app_files_router.py
@@ -1,4 +1,5 @@
 from typing import Literal
+from urllib.parse import quote
 
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import HTMLResponse
@@ -67,9 +68,13 @@ async def get_app_file(
         build_info.created_at.strftime("%Y-%m-%d_%H-%M-%S") if build_info.created_at else ""
     )
     file_name = f"{build_info.app_title} {build_info.bundle_version}{created_at_prefix}"
+    
+    # Encode the filename for HTTP headers
+    safe_filename = quote(file_name) 
+    content_disposition = f"attachment; filename*=UTF-8''{safe_filename}.{file_type}"
 
     return Response(
         content=app_file_content,
         media_type="application/octet-stream",
-        headers={"Content-Disposition": f"attachment; filename={file_name}.{file_type}"},
+        headers={"Content-Disposition": content_disposition},
     )


### PR DESCRIPTION
Previously, the server failed to handle APK filenames containing non-Latin characters (e.g., Chinese) due to HTTP header encoding limitations. The `latin-1` requirement for headers caused `UnicodeEncodeError` when returning filenames with Unicode characters.

This change:
1. Uses `urllib.parse.quote()` to percent-encode Unicode filenames
2. Adopts RFC 5987 `filename*=` syntax with UTF-8 encoding
3. Ensures compatibility with browsers while preserving original filenames

Example:
- Old: `filename=测试.apk` → Broken (invalid header)
- New: `filename*=UTF-8''%E6%B5%8B%E8%AF%95.apk` → Works (decodes as "测试.apk")

Fixes #38