### PR TITLE
For iOS CFBundleDisplayName is the better name to display

### DIFF
--- a/app_distribution_server/build_info.py
+++ b/app_distribution_server/build_info.py
@@ -92,7 +92,7 @@ def get_build_info_from_ipa(
 
                 info = plistlib.loads(plist_file_content)
                 bundle_id = info.get("CFBundleIdentifier")
-                app_title = info.get("CFBundleName")
+                app_title = info.get("CFBundleDisplayName")
                 bundle_version = info.get("CFBundleShortVersionString")
 
                 if bundle_id is None or app_title is None or bundle_version is None:


### PR DESCRIPTION
On iOS, the CFBundleDisplayName from Info.plist is the name shown on the home screen.
This is the more correct name to display when showing the installation page.